### PR TITLE
Correct component paths in App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,9 +17,9 @@
 <script setup>
 import Header from './components/HeaderSection.vue'
 import Balance from './components/BalanceSection.vue'
-import IncomeExpenses from '../../vue-expense-tracker/src/components/IncomeExpenses.vue'
-import TransactionList from '../../vue-expense-tracker/src/components/TransactionList.vue'
-import AddTransaction from '../../vue-expense-tracker/src/components/AddTransaction.vue'
+import IncomeExpenses from './components/IncomeExpenses.vue'
+import TransactionList from './components/TransactionList.vue'
+import AddTransaction from './components/AddTransaction.vue'
 import { useExpenseTrackerStore } from '@/stores/transactions.js'
 import { onMounted, computed } from 'vue'
 import { useToast } from 'vue-toastification'


### PR DESCRIPTION
Corrected the import paths of components in App.vue file. Previously, they were pointing towards a different project's structure, which could potentially introduce bugs or cause confusion. Now, all component paths are consistent and point to the current project's structure.